### PR TITLE
Botactions as interface push

### DIFF
--- a/src/bot_actions/bot_action.ts
+++ b/src/bot_actions/bot_action.ts
@@ -1,7 +1,7 @@
 import { GitLabAPIRequest } from "../gitlab";
 
 /**
- * This extensible class defines the core properties that are dynamically
+ * This interface defines the core properties that are dynamically
  * calculated by each distinct Bot Action:
  * 1. `apiRequest` is an object containing information about the success or failure of the api call to GitLab
  * 1. `goodGitPractice` represents whether or not the Merge Request event meets the criteria for good behavior
@@ -9,11 +9,8 @@ import { GitLabAPIRequest } from "../gitlab";
  * @remarks 'goodGitPractice' will be undefined when Bot Action logic couldn't be performed due to api
  * failure in order to distinguish from when its value is explicitly set to false after performing some logic.
  * */
-// TODO: look into possibility of making BotAction an abstract class
-export class BotAction {
-  constructor(
-    readonly apiRequest: GitLabAPIRequest,
-    readonly goodGitPractice: boolean,
-    readonly mrNote: string,
-  ) {}
+export interface BotAction {
+  apiRequest: GitLabAPIRequest;
+  goodGitPractice: boolean;
+  mrNote: string;
 }

--- a/src/bot_actions/branch_age/branch_age.ts
+++ b/src/bot_actions/branch_age/branch_age.ts
@@ -15,15 +15,13 @@ import { GitLabCommit } from "../../interfaces";
  * of this class also contains the property:
  * 1. `oldestCommit`: `GitLabCommit` with the oldest created_at date contained in the Merge Request
  */
-export class BranchAge extends BotAction {
+export class BranchAge implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
     readonly oldestCommit: GitLabCommit,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+  ) {}
 
   /**
    * Constructs a complete Branch Age object by making an HTTP call and analyzing response.

--- a/src/bot_actions/commit_messages/commit_messages.ts
+++ b/src/bot_actions/commit_messages/commit_messages.ts
@@ -14,15 +14,13 @@ import { CommitMessagesNote } from "./commit_message_note";
  * of this class also contains the property:
  * 1. `calculatedThreshold`: `number` the number of failing commit titles that will result in bad practice for an individual commit message criteria
  */
-export class CommitMessages extends BotAction {
+export class CommitMessages implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
     readonly calculatedThreshold: number,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+  ) {}
 
   /**
    * Constructs a complete Commit Message object by making an HTTP call and analyzing response.

--- a/src/bot_actions/diff_size/diff_size.ts
+++ b/src/bot_actions/diff_size/diff_size.ts
@@ -16,15 +16,13 @@ import { Change } from "../../interfaces";
  * of this class also contains the property:
  * 1. `totalDiffs`: `number` lines of diff contained in the Merge Request
  */
-export class DiffSize extends BotAction {
+export class DiffSize implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
     readonly totalDiffs: number,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+  ) {}
 
   /**
    * Constructs a complete DiffSize object by making an HTTP call and analyzing response.

--- a/src/bot_actions/git_outta_here/git_outta_here.ts
+++ b/src/bot_actions/git_outta_here/git_outta_here.ts
@@ -10,14 +10,12 @@ import { GitOuttaHereNote } from "./git_outta_here_note";
 /**
  * This class extends the `BotAction` class by checking for log files in the changes contained in the GitLab Merge Request.
  */
-export class GitOuttaHere extends BotAction {
+export class GitOuttaHere implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
+  ) {}
 
   /**
    * Constructs a complete Bot Action object by making an HTTP call and analyzing response.
@@ -45,7 +43,7 @@ export class GitOuttaHere extends BotAction {
       goodGitPractice = this.noLogFiles(apiResponse.result.changes);
     }
 
-    return new BotAction(
+    return new GitOuttaHere(
       apiResponse.apiRequest,
       goodGitPractice,
       GitOuttaHereNote.buildMessage(

--- a/src/bot_actions/new_git_who_dis/new_git_who_dis.ts
+++ b/src/bot_actions/new_git_who_dis/new_git_who_dis.ts
@@ -6,14 +6,12 @@ import { NewGitWhoDisNote } from "./new_git_who_dis_note";
 /**
  * This class extends the `BotAction` class by analyzing the name of the author of the GitLab Merge Request.
  */
-export class NewGitWhoDis extends BotAction {
+export class NewGitWhoDis implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
+  ) {}
 
   /**
    * Constructs a complete Bot Action object by analyzing the author name.
@@ -29,7 +27,7 @@ export class NewGitWhoDis extends BotAction {
     const goodGitPractice: boolean = this.authorNameIsNotLanId(authorName);
     const apiResponse: GitLabGetResponse = GitLabGetResponse.noRequestNeeded();
 
-    return new BotAction(
+    return new NewGitWhoDis(
       apiResponse.apiRequest,
       goodGitPractice,
       NewGitWhoDisNote.buildMessage(authorName, goodGitPractice, logger),

--- a/src/bot_actions/self_merge/self_merge.ts
+++ b/src/bot_actions/self_merge/self_merge.ts
@@ -16,15 +16,13 @@ import { User } from "../../interfaces/gitlab_api_types";
  * 1. `approversNeeded`: `boolean` If true, Merge Request is merged with approvers. If false, Merge Request is merged without approvers.
  * If undefined, Merge Request is not merged.
  */
-export class SelfMerge extends BotAction {
+export class SelfMerge implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
     readonly approversNeeded: boolean | undefined,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+  ) {}
 
   /**
    * Constructs a complete Self Merge object by analyzing the assignee id and author id or by analyzing the response(s) of HTTP call(s).

--- a/src/bot_actions/too_many_assigned/too_many_assigned.ts
+++ b/src/bot_actions/too_many_assigned/too_many_assigned.ts
@@ -11,14 +11,12 @@ import { TooManyAssignedNote } from "./too_many_assigned_note";
 /**
  * This class extends the `BotAction` class by analyzing the number of merge requests assigned to the assignee of the GitLab Merge Request.
  */
-export class TooManyAssigned extends BotAction {
+export class TooManyAssigned implements BotAction {
   private constructor(
-    apiRequest: GitLabAPIRequest,
-    goodGitPractice: boolean,
-    mrNote: string,
-  ) {
-    super(apiRequest, goodGitPractice, mrNote);
-  }
+    readonly apiRequest: GitLabAPIRequest,
+    readonly goodGitPractice: boolean,
+    readonly mrNote: string,
+  ) {}
 
   /**
    * Constructs a complete Bot Action object by making an HTTP call and analyzing response when the state is "merge" and the assigneeId is not null.
@@ -56,7 +54,7 @@ export class TooManyAssigned extends BotAction {
       apiResponse = GitLabGetResponse.noRequestNeeded();
     }
 
-    return new BotAction(
+    return new TooManyAssigned(
       apiResponse.apiRequest,
       goodGitPractice,
       TooManyAssignedNote.buildMessage(


### PR DESCRIPTION
make BotAction an interface: there is no need for it to be a class or abstract class since it has no shared function signatures or implemented methods at this time

resolve #7 