### PR TITLE
Logging hotfix

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -106,6 +106,12 @@ const handleGitLabWebhook = async (event: any): Promise<LambdaResponse> => {
   return response;
 };
 
+const handleHealthCheck = (containerId: string, event: any): LambdaResponse => {
+  winlog.info(`CloudWatch timer healthcheck. Container ID: ${containerId}`);
+  winlog.info(event);
+  return new HealthCheckResponse();
+};
+
 /**
  * Lambda function that processes incoming events.
  * @param event GitLab webhook or CloudWatch Rule that triggers lambda. The `body` property
@@ -127,9 +133,7 @@ const webhook: Handler = async (
 
   const response = event.hasOwnProperty("body")
     ? await handleGitLabWebhook(event)
-    : new HealthCheckResponse();
-
-  winlog.info(response);
+    : handleHealthCheck(containerId, event);
 
   return response;
 };

--- a/src/merge_request/bot_actions_response.ts
+++ b/src/merge_request/bot_actions_response.ts
@@ -17,6 +17,7 @@ import {
   getMergeRequestEventData,
 } from "../merge_request";
 import { CustomConfig } from "../custom_config/custom_config";
+import { winlog } from "../util";
 
 /**
  * This class contains the aggregation logic for invoking Bot Actions and using their responses to post a comment and emoji on the Merge Request.
@@ -174,7 +175,7 @@ export class BotActionsResponse implements LambdaResponse {
       statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
-    const responseBody = JSON.stringify({
+    const responseBody = {
       mergeRequestEvent,
       customConfig,
       branchAge,
@@ -186,9 +187,14 @@ export class BotActionsResponse implements LambdaResponse {
       tooManyAssigned,
       comment,
       emoji,
+    };
+
+    winlog.info({
+      statusCode: statusCode,
+      body: responseBody,
     });
 
-    return new BotActionsResponse(statusCode, responseBody);
+    return new BotActionsResponse(statusCode, JSON.stringify(responseBody));
   }
 
   /**

--- a/src/merge_request/bot_actions_response.ts
+++ b/src/merge_request/bot_actions_response.ts
@@ -17,7 +17,6 @@ import {
   getMergeRequestEventData,
 } from "../merge_request";
 import { CustomConfig } from "../custom_config/custom_config";
-import { winlog } from "../util";
 
 /**
  * This class contains the aggregation logic for invoking Bot Actions and using their responses to post a comment and emoji on the Merge Request.
@@ -189,7 +188,7 @@ export class BotActionsResponse implements LambdaResponse {
       emoji,
     };
 
-    winlog.info({
+    logger.info({
       statusCode: statusCode,
       body: responseBody,
     });


### PR DESCRIPTION
* Log `BotActionsResponse` to CloudWatch before it is stringified
* Recapture CloudWatch timer event in logs