### PR TITLE
More elegant handling of gitlab vs healthcheck events

### DIFF
--- a/__tests__/live_gitlab_api_tests/live_gitlab_api.test.ts
+++ b/__tests__/live_gitlab_api_tests/live_gitlab_api.test.ts
@@ -362,6 +362,9 @@ describe("Live lambda handler response with mocked Infra (Error Cases)", () => {
   test("Bad GitLab API token: returns IncorrectPermissionsResponse", () => {
     // test fixture needs to be created within test scope to make sure it has access to dynamic values
     openEvent = {
+      headers: {
+        "X-Gitlab-Event": "Merge Request Hook",
+      },
       body: JSON.stringify(
         mockGitLabWebhookEvent(
           USER_ID,

--- a/src/interfaces/i_lambda_response.ts
+++ b/src/interfaces/i_lambda_response.ts
@@ -17,9 +17,17 @@ export class HealthCheckResponse implements LambdaResponse {
   readonly body: string;
   readonly statusCode: number;
 
-  constructor(containerId: string, readonly event: any) {
+  constructor(event: any, containerId?: string) {
     this.statusCode = HttpStatus.IM_A_TEAPOT;
-    this.body = `CloudWatch timer healthcheck. Container ID: ${containerId}`;
+
+    if (event.source === "aws.events") {
+      // lambda warmer ping
+      this.body = `CloudWatch timer healthcheck. Container ID: ${containerId}`;
+    } else {
+      // external infra ping
+      this.body = `External ${event.headers["Healthcheck"]} infra healthcheck.`;
+    }
+
     logger.info(this);
   }
 }


### PR DESCRIPTION
* update `handler.ts` to determine incoming event type based on header
* update `HealthCheckResponse` class to distinguish between CloudWatch lambda warmer rule and external infrastructure healthcheck pings
  * healthcheck tests external to AWS environment now need to include a header called "Healthcheck"