### PR TITLE
Header & HTTP code hotfix

### DIFF
--- a/__tests__/component_builder_tests_with_mocks/handler.test.ts
+++ b/__tests__/component_builder_tests_with_mocks/handler.test.ts
@@ -62,7 +62,7 @@ const externalInfraTestEvent = {
 
 const nonMREvent = {
   headers: {
-    "X-Gitlab-Event": "Merge Request Hook",
+    "X-Gitlab-Event": "Push Hook",
   },
   body: '{"object_kind":"push"}',
 };

--- a/__tests__/live_gitlab_api_tests/live_gitlab_api.test.ts
+++ b/__tests__/live_gitlab_api_tests/live_gitlab_api.test.ts
@@ -332,6 +332,9 @@ describe("Live Integration Tests: mergeRequestApi.getSingleMR", () => {
 describe("Live Integration API Tests: handler.handleGitLabWebhook responses", () => {
   test("Open State: returns CommentSuccessResponse", async () => {
     const openEvent = {
+      headers: {
+        "X-Gitlab-Event": "Merge Request Hook",
+      },
       body: JSON.stringify(
         mockGitLabWebhookEvent(
           USER_ID,

--- a/handler.ts
+++ b/handler.ts
@@ -7,12 +7,7 @@ import {
   NotSupportedResponse,
 } from "./src/interfaces";
 import { GitLabApi } from "./src/gitlab";
-import {
-  getMrId,
-  getObjectKind,
-  getProjectId,
-  getState,
-} from "./src/merge_request";
+import { getMrId, getProjectId, getState } from "./src/merge_request";
 import { getToken, getBaseURI } from "./src/util";
 import { CustomConfig } from "./src/custom_config/custom_config";
 import { runBotActions } from "./src/bot_actions";
@@ -38,9 +33,7 @@ const handleGitLabWebhook = async (event: any): Promise<LambdaResponse> => {
 
   try {
     gitLabEvent = JSON.parse(event.body);
-    objectKind = getObjectKind(gitLabEvent);
   } catch (err) {
-    objectKind = undefined;
     response = new ErrorResponse(`Error parsing event.body: ${err.message}`);
   }
 
@@ -52,8 +45,8 @@ const handleGitLabWebhook = async (event: any): Promise<LambdaResponse> => {
   }
 
   if (!(response instanceof ErrorResponse)) {
-    switch (objectKind) {
-      case "merge_request":
+    switch (event.headers["X-Gitlab-Event"]) {
+      case "Merge Request Hook":
         const state = getState(gitLabEvent);
         /**
          * We only perform analysis on Merge Request events in the following states
@@ -94,7 +87,7 @@ const handleGitLabWebhook = async (event: any): Promise<LambdaResponse> => {
         break;
       default:
         /** No action required for any incoming GitLab event that is not a merge request */
-        response = new NotSupportedResponse(objectKind);
+        response = new NotSupportedResponse(event.headers["X-Gitlab-Event"]);
     }
   }
 

--- a/handler.ts
+++ b/handler.ts
@@ -28,7 +28,7 @@ let containerId: string;
  */
 const handleGitLabWebhook = async (event: any): Promise<LambdaResponse> => {
   let gitLabEvent: any;
-  let token, baseURI, objectKind: string | undefined;
+  let token, baseURI;
   let response!: LambdaResponse;
 
   try {

--- a/src/interfaces/i_lambda_response.ts
+++ b/src/interfaces/i_lambda_response.ts
@@ -18,7 +18,7 @@ export class HealthCheckResponse implements LambdaResponse {
   readonly statusCode: number;
 
   constructor(event: any, containerId?: string) {
-    this.statusCode = HttpStatus.IM_A_TEAPOT;
+    this.statusCode = HttpStatus.OK;
 
     if (event.source === "aws.events") {
       // lambda warmer ping
@@ -74,7 +74,7 @@ export class NotSupportedResponse implements LambdaResponse {
  */
 export class IncorrectPermissionsResponse implements LambdaResponse {
   readonly body: string;
-  readonly statusCode = 401;
+  readonly statusCode = HttpStatus.UNAUTHORIZED;
 
   constructor(event: MergeRequestEvent) {
     this.body = JSON.stringify(event);
@@ -90,7 +90,7 @@ export class IncorrectPermissionsResponse implements LambdaResponse {
  */
 export class CommentFailedResponse implements LambdaResponse {
   readonly body: string;
-  readonly statusCode = 500;
+  readonly statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
 
   constructor(
     mrEvent: MergeRequestEvent,
@@ -122,7 +122,7 @@ export class CommentFailedResponse implements LambdaResponse {
  */
 export class CommentSuccessResponse implements LambdaResponse {
   readonly body: string;
-  readonly statusCode = 201;
+  readonly statusCode = HttpStatus.CREATED;
 
   constructor(
     mrEvent: MergeRequestEvent,
@@ -154,7 +154,7 @@ export class CommentSuccessResponse implements LambdaResponse {
  */
 export class NoCommentNeededResponse implements LambdaResponse {
   readonly body: string;
-  readonly statusCode = 200;
+  readonly statusCode = HttpStatus.OK;
 
   constructor(
     mrEvent: MergeRequestEvent,

--- a/src/merge_request/helpers.ts
+++ b/src/merge_request/helpers.ts
@@ -12,9 +12,6 @@ export const getProjectId = (event: any): number => {
   return event.project.id;
 };
 
-export const getObjectKind = (event: any): string => {
-  return event.object_kind;
-};
 export const getState = (event: any): string => {
   return event.object_attributes.action;
 };


### PR DESCRIPTION
* Use header values wherever possible
* Replace `418` with `200` for healthchecks
* Consistently use `HttpStatus` library instead of hardcoded numbers